### PR TITLE
Added NER postprocessing scripts

### DIFF
--- a/tmdm/pipe/pipe.py
+++ b/tmdm/pipe/pipe.py
@@ -83,3 +83,13 @@ class PipeElement:
             assert len(docs) == len(annotated_batch)
             for doc, annotations in zip(docs, annotated_batch):
                 setattr(doc._, self.field, annotations)
+
+            if self.name == 'ner':
+                allnestuples = self.provider.postprocess_batch(docs)
+
+                for doc in docs:
+                    for ne in doc._.nes:
+                        ne.cache.clear()
+
+                for doc, nestuples in zip(docs, allnestuples):
+                    setattr(doc._, self.field, nestuples)

--- a/tmdm/transformers/ne.py
+++ b/tmdm/transformers/ne.py
@@ -52,6 +52,39 @@ class OnlineNerProvider(OnlineProvider):
         return [self.converter(doc, next(batched_results_iter)) for doc in docs]
 
 
+    def postprocess_batch(self, docs: List[Doc]) -> List[CharOffsetAnnotation]:
+        alltuples = []
+        for doc in docs:
+            doctuples = []
+            for ne in doc._.nes:
+                doctuples.append([ne.start_char, ne.end_char, ne.label_])
+
+            # Merge until cannot merge anymore
+            changed = True
+            while changed:
+                changed = False
+                for i in range(len(doctuples)-1):
+                    if doctuples[i] == None:
+                        continue
+
+                    end1 = doctuples[i][1]
+                    start2 = doctuples[i+1][0]
+                    if end1 == start2 or (end1+1) == start2:
+                        doctuples[i][1] = doctuples[i+1][1]
+                        changed = True
+                        doctuples[i+1] = None
+
+                for i in range(len(doctuples)-1,0,-1):
+                    if doctuples[i] == None:
+                        del doctuples[i]
+
+            for i in range(len(doctuples)):
+                doctuples[i] = tuple(doctuples[i])
+            alltuples.append(doctuples)
+
+        return alltuples
+
+
 def get_ne_pipe(model: str = None, tokenizer: str = None, cuda=-1):
     return PipeElement(name='ner', field='nes',
                        provider=OnlineNerProvider("ner", path_or_name=model, path_or_name_tokenizer=tokenizer,


### PR DESCRIPTION
* After NER finds entities, they are merged if there is 1 or less characters between them

* Character offsets are now the relaxed ones

Note: It 'clears' cache for each named entity but the actual behaviour/ outputs show that it doesn't remake objects that haven't been changed by the postprocessing, only the ones that have been.

Another note: Could be worth changing it so that the 'type' (e.g. Miscalenous  or Person) comes from second rather than first entity as that is likely to be more accurate.